### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/public/fonts/demo-files/demo.js
+++ b/public/fonts/demo-files/demo.js
@@ -14,8 +14,14 @@ document.body.addEventListener("click", function(e) {
     var fontSize = document.getElementById('fontSize'),
         testDrive = document.getElementById('testDrive'),
         testText = document.getElementById('testText');
+    function escapeHTML(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
     function updateTest() {
-        testDrive.innerHTML = testText.value || String.fromCharCode(160);
+        testDrive.innerHTML = escapeHTML(testText.value) || String.fromCharCode(160);
         if (window.icomoonLiga) {
             window.icomoonLiga(testDrive);
         }


### PR DESCRIPTION
Fixes [https://github.com/ByteBeam-OSS/home-vue/security/code-scanning/1](https://github.com/ByteBeam-OSS/home-vue/security/code-scanning/1)

To fix the problem, we need to ensure that any text from the `testText` input field is properly escaped before being assigned to `testDrive.innerHTML`. This can be achieved by using a text node or a utility function to escape HTML special characters.

The best way to fix this without changing existing functionality is to create a utility function that escapes HTML special characters and use it to sanitize the input value before assigning it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
